### PR TITLE
Attribute-based selection and manipulation of business objects

### DIFF
--- a/src/SharpMap.BusinessObjects/Data/Providers/Business/BusinessObjectAccessBase.cs
+++ b/src/SharpMap.BusinessObjects/Data/Providers/Business/BusinessObjectAccessBase.cs
@@ -91,10 +91,28 @@ namespace SharpMap.Data.Providers.Business
         public abstract void Delete(IEnumerable<T> businessObjects);
 
         /// <summary>
+        /// Attribute-based deletion according to provided <paramref name="match"/>
+        /// </summary>
+        /// <param name="match"><typeparamref name="Predicate<T>"/> identifying business objects to be deleted</param>
+        public virtual void Delete(Predicate<T> match)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Insert the provided <paramref name="businessObjects"/>
         /// </summary>
         /// <param name="businessObjects">The features that need to be inserted</param>
         public abstract void Insert(IEnumerable<T> businessObjects);
+
+        /// <summary>
+        /// Insert provided <paramref name="businessObject"/> and expand extents
+        /// </summary>
+        /// <param name="businessObject">The business object to be inserted</param>
+        public virtual void Insert(T businessObject)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// Method to get the geometry of a specific feature
@@ -135,6 +153,35 @@ namespace SharpMap.Data.Providers.Business
             if (CachedExtents == null)
                 throw new InvalidOperationException("You need to set Cached before using this function or override GetExtents");
             return CachedExtents;
+        }
+
+        /// <summary>
+        /// Attribute-based selection according to <paramref name="match"/>
+        /// </summary>
+        /// <param name="match">The predicate</param>
+        /// <returns>The the first business object matching the predicate</returns>
+        public virtual T Find(Predicate<T> match)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Attribute-based selection according to <paramref name="match"/>
+        /// </summary>
+        /// <param name="match">The predicate</param>
+        /// <returns>An array of business objects matching the predicate</returns>
+        public virtual T[] FindAll(Predicate<T> match)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// The business objects contained by the Source
+        /// </summary>
+        /// <returns>A shallow copy of the business objects</returns>
+        public virtual T[] AsReadOnly()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/SharpMap.BusinessObjects/Data/Providers/Business/BusinessObjectFilterProvider.cs
+++ b/src/SharpMap.BusinessObjects/Data/Providers/Business/BusinessObjectFilterProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SharpMap.Data.Providers.Business
+{
+    public abstract class BusinessObjectFilterProvider
+    {
+        public delegate bool FilterMethod(object bo);
+        public FilterMethod FilterDelegate { get; set; }
+    }
+}

--- a/src/SharpMap.BusinessObjects/Data/Providers/Business/BusinessObjectProvider.cs
+++ b/src/SharpMap.BusinessObjects/Data/Providers/Business/BusinessObjectProvider.cs
@@ -140,7 +140,7 @@ namespace SharpMap.Data.Providers.Business
                 GetPublicMembers(t.BaseType, collection);
         }
 
-        protected readonly IBusinessObjectSource<TFeature> _source;
+        private readonly IBusinessObjectSource<TFeature> _source;
 
         /// <summary>
         /// Creates an instance of this class

--- a/src/SharpMap.BusinessObjects/Data/Providers/Business/BusinessObjectProvider.cs
+++ b/src/SharpMap.BusinessObjects/Data/Providers/Business/BusinessObjectProvider.cs
@@ -140,7 +140,7 @@ namespace SharpMap.Data.Providers.Business
                 GetPublicMembers(t.BaseType, collection);
         }
 
-        private readonly IBusinessObjectSource<TFeature> _source;
+        protected readonly IBusinessObjectSource<TFeature> _source;
 
         /// <summary>
         /// Creates an instance of this class

--- a/src/SharpMap.BusinessObjects/Data/Providers/Business/IBusinessObjectSource.cs
+++ b/src/SharpMap.BusinessObjects/Data/Providers/Business/IBusinessObjectSource.cs
@@ -15,6 +15,7 @@
 // along with SharpMap; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using GeoAPI.Geometries;
@@ -73,10 +74,22 @@ namespace SharpMap.Data.Providers.Business
         void Delete(IEnumerable<T> businessObjects);
 
         /// <summary>
+        /// Attribute-based deletion according to provided <paramref name="match"/>
+        /// </summary>
+        /// <param name="match"><typeparamref name="Predicate<T>"/> identifying business objects to be deleted</param>
+        void Delete(Predicate<T> match);
+
+        /// <summary>
         /// Insert the provided <paramref name="businessObjects"/>
         /// </summary>
         /// <param name="businessObjects">The features that need to be inserted</param>
         void Insert(IEnumerable<T> businessObjects);
+
+        /// <summary>
+        /// Insert provided <paramref name="businessObject"/> and expand extents
+        /// </summary>
+        /// <param name="businessObject">The business object to be inserted</param>
+        void Insert(T businessObject);
 
         /// <summary>
         /// Method to get the geometry of a specific feature
@@ -102,5 +115,26 @@ namespace SharpMap.Data.Providers.Business
         /// </summary>
         /// <returns>The extents</returns>
         Envelope GetExtents();
+
+        /// <summary>
+        /// Attribute-based selection according to <paramref name="match"/>
+        /// </summary>
+        /// <param name="match">The predicate</param>
+        /// <returns>The the first business object matching the predicate</returns>
+        T Find(Predicate<T> match);
+
+        /// <summary>
+        /// Attribute-based selection according to <paramref name="match"/>
+        /// </summary>
+        /// <param name="match">The predicate</param>
+        /// <returns>An array of business objects matching the predicate</returns>
+        T[] FindAll(Predicate<T> match);
+
+        /// <summary>
+        /// The business objects contained by the Source
+        /// </summary>
+        /// <returns>A shallow copy of the business objects</returns>
+        T[] AsReadOnly();
+
     }
 }

--- a/src/SharpMap.BusinessObjects/Data/Providers/Business/InMemoryBusinessObjectSource.cs
+++ b/src/SharpMap.BusinessObjects/Data/Providers/Business/InMemoryBusinessObjectSource.cs
@@ -55,7 +55,19 @@ namespace SharpMap.Data.Providers.Business
         {
             get { return _title; }
         }
-
+        /// <summary>
+        /// Collection of business objects for querying using Select(IQueryable<T> query)
+        /// or to directly edit attributes of one or more objects
+        ///</summary>
+        public ICollection<T> Context
+        {
+            get
+            {
+                lock (((ICollection)_businessObjects).SyncRoot)
+                    return _businessObjects.Values;
+            }
+        }
+        
         /// <summary>
         /// Select a set of features based on <paramref name="box"/>
         /// </summary>
@@ -136,6 +148,32 @@ namespace SharpMap.Data.Providers.Business
                 }
                 CachedExtents = null;
             }
+        }
+
+        /// <summary>
+        /// Delete objects by provided <paramref name="oids"/>
+        /// </summary>
+        /// <param name="oids">ObjectIds of features to be deleted</param>
+        public void Delete(IEnumerable<uint> oids)
+        {
+            lock (((ICollection)_businessObjects).SyncRoot)
+            {
+                foreach (uint oid in oids)
+                {
+                    _businessObjects.Remove(oid);
+                }
+                CachedExtents = null;
+            }
+        }
+
+        public void Clear()
+        {
+            lock (((ICollection)_businessObjects).SyncRoot)
+            {
+                _businessObjects.Clear();
+                CachedExtents = null;
+            }
+
         }
 
         /// <summary>

--- a/src/SharpMap.BusinessObjects/Data/Providers/Business/InMemoryBusinessObjectSource.cs
+++ b/src/SharpMap.BusinessObjects/Data/Providers/Business/InMemoryBusinessObjectSource.cs
@@ -55,19 +55,20 @@ namespace SharpMap.Data.Providers.Business
         {
             get { return _title; }
         }
-        /// <summary>
-        /// Collection of business objects for querying using Select(IQueryable<T> query)
-        /// or to directly edit attributes of one or more objects
-        ///</summary>
-        public ICollection<T> Context
-        {
-            get
-            {
-                lock (((ICollection)_businessObjects).SyncRoot)
-                    return _businessObjects.Values;
-            }
-        }
-        
+        ///// <summary>
+        ///// Collection of business objects for querying using Select(IQueryable<T> query)
+        ///// or to directly edit attributes of one or more objects
+        /////</summary>
+        //public ICollection<T> Context
+        //{
+        //    get
+        //    {
+        //        lock (((ICollection)_businessObjects).SyncRoot)
+        //            return _businessObjects.Values;
+        //    }
+        //}
+
+      
         /// <summary>
         /// Select a set of features based on <paramref name="box"/>
         /// </summary>
@@ -151,6 +152,22 @@ namespace SharpMap.Data.Providers.Business
         }
 
         /// <summary>
+        /// Attribute-based deletion according to provided <paramref name="match"/>
+        /// </summary>
+        /// <param name="match"><typeparamref name="Predicate<T>"/> identifying business objects to be deleted</param>
+        public override void Delete(Predicate<T> match)
+        {
+            lock (((ICollection)_businessObjects).SyncRoot)
+            {
+                foreach (T bo in FindAll(match))
+                {
+                    _businessObjects.Remove(_getId(bo));
+                }
+                CachedExtents = null;
+            }
+        }
+
+        /// <summary>
         /// Delete objects by provided <paramref name="oids"/>
         /// </summary>
         /// <param name="oids">ObjectIds of features to be deleted</param>
@@ -192,20 +209,30 @@ namespace SharpMap.Data.Providers.Business
             }
         }
 
-        public void InsertFeature(T feature)
+        /// <summary>
+        /// Insert provided <paramref name="businessObject"/> and expand extents
+        /// </summary>
+        /// <param name="businessObject">The business object to be inserted</param>
+        public override void Insert(T businessObject)
         {
             lock (((ICollection)_businessObjects).SyncRoot)
             {
-                _businessObjects.Add(_getId(feature), feature);
+                _businessObjects.Add(_getId(businessObject), businessObject);
 
                 // expand to include
                 var res = CachedExtents ?? new Envelope();
 
-                var g = _getGeometry(feature);
+                var g = _getGeometry(businessObject);
                 if (g != null && !g.IsEmpty)
                     res.ExpandToInclude(g.EnvelopeInternal);
                 CachedExtents = res;
             }
+        }
+
+        [Obsolete("Use Insert(T businessObject)")]
+        public void InsertFeature(T feature)
+        {
+            Insert(feature);
         }
 
         public override int Count
@@ -235,6 +262,54 @@ namespace SharpMap.Data.Providers.Business
                 }
                 return res;
             }
+        }
+
+        /// <summary>
+        /// Attribute-based selection according to <paramref name="match"/>
+        /// </summary>
+        /// <param name="match">The predicate</param>
+        /// <returns>The the first business object matching the predicate</returns>
+        public override T[] FindAll(Predicate<T> match)
+        {
+            T[] objList;
+            lock (((ICollection)_businessObjects).SyncRoot)
+            {
+                objList = new T[_businessObjects.Count];
+                _businessObjects.Values.CopyTo(objList, 0);
+            }
+            return Array.FindAll(objList, match);
+        }
+
+        /// <summary>
+        /// Attribute-based selection according to <paramref name="match"/>
+        /// </summary>
+        /// <param name="match">The predicate</param>
+        /// <returns>The the first business object matching the predicate</returns>
+        public override T Find(Predicate<T> match)
+        {
+            T[] objList;
+            lock (((ICollection)_businessObjects).SyncRoot)
+            {
+                objList = new T[_businessObjects.Count];
+                _businessObjects.Values.CopyTo(objList, 0);
+            }
+            return Array.Find(objList, match);
+        }
+
+        /// <summary>
+        /// The business objects contained by the Source
+        /// </summary>
+        /// <returns>A shallow copy of the business objects</returns>
+        public override T[] AsReadOnly()
+        {
+            T[] objList;
+            lock (((ICollection)_businessObjects).SyncRoot)
+            {
+                objList = new T[_businessObjects.Count];
+                _businessObjects.Values.CopyTo(objList, 0);
+            }
+            return objList;
+
         }
     }
 }


### PR DESCRIPTION
Implement various predicate-based methods for working with business objects, particularly for `InMemoryBusinessObjectSource` along with new test methods. These changes void commit made on 9 Apr 2018.

Question: 
Are the following new methods useful for Mongo / EF6 implementations?
````
T Find(Predicate<T> match);
T[] FindAll(Predicate<T> match);
T[] AsReadOnly();
void Delete(Predicate<T> match);
````
If not, maybe the new methods/props should be moved from `public interface IBusinessObjectSource<T>` and implemented directly on `InMemoryBusinessObjectSource<T>`. Main purpose of `IBusinessObjectSource<T>` seems to be for `BusinessObjectLayer` but it already has some non-layer specific methods/props so I put it there to start with.